### PR TITLE
Try to add a notification to the page for COVID-19

### DIFF
--- a/_data/homepage.yml
+++ b/_data/homepage.yml
@@ -15,6 +15,10 @@ hero-title: Board of Architects
 hero-subtitle: We help regulate Singapore's architectural profession and celebrate good designs
 hero-banner: /images/boa-hero-banner-min.jpg
 
+# Notification
+notification: "Due to the COVID-19 situation, BOA will be implementing measures to manage person-to-person contact.<br><br>
+We seek your understanding on the precautions taken and apologise for the inconvenience caused"
+
 #Call to Action Button
 button:
   - text: Learn More


### PR DESCRIPTION
This Pull Request is to `staging` and attempts to demonstrate how one can add a notification banner to the Board of Architects' Isomer page